### PR TITLE
Remove description

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,13 +5,6 @@ project:
 book:
   title: "Hands-On Programming with R"
   author: "Garrett Grolemund"
-  description: | 
-    This book will teach you how to program in R, with hands-on examples. I 
-    wrote it for non-programmers to provide a friendly introduction to the R
-    language. You'll learn how to load data, assemble and disassemble data 
-    objects, navigate R's environment system, write your own functions, and
-    use all of R's programming tools. Throughout the book, you'll use your
-    newfound skills to solve practical data science problems.
   cover-image: images/cover.png
   site-url: https://rstudio-education.github.io/hopr/
   repo-url: https://github.com/jjallaire/hopr/


### PR DESCRIPTION
Title blocks in Quarto now display the description when present, so don't include it.